### PR TITLE
最新版のRailsチュートリアルがスターターキットで使えるようにREADMEを変更する

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,15 @@ Railsチュートリアルが始められる環境が整います (Windows 8 / M
 ```
 
 ## 本ツールを使った環境構築の手順
-
 1. [VirtualBox](http://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html?ssSourceSiteId=otnjp)をインストールする
 2. [Vagrant](https://www.vagrantup.com/downloads.html)をインストールする
-3. Windowsの場合: 英字のローカルアカウントを作る (`ror`など)
-4. Windowsの場合: sshクライアント([TeraTerm](http://ttssh2.sourceforge.jp/)など)をインストールする
+3. ~~Windowsの場合: 英字のローカルアカウントを作る (`ror`など)~~
+4. ~~Windowsの場合: sshクライアント([TeraTerm](http://ttssh2.sourceforge.jp/)など)をインストールする~~
 5. `Vagrantfile` があるディレクトリに移動して、`vagrant up`を実行する
 6. `vagrant ssh` でゲストOSにログインする
 7. `ruby --version` や `rails --version` でちゃんと動くか確かめる
+
+(*Windowsでの利用の確認は現在取れていません、現在対応中のためお待ち下さい*)
 
 ### 動作確認
 

--- a/README.md
+++ b/README.md
@@ -45,21 +45,6 @@ Railsチュートリアルが始められる環境が整います (Windows 8 / M
 6. `vagrant ssh` でゲストOSにログインする
 7. `ruby --version` や `rails --version` でちゃんと動くか確かめる
 
-### 最新版のRailsを使う
-ステップ`7.`を行なった際に表示されるバージョンが`ruby 2.0.0p643...`と`Rails 4.0.5`だ
-
-バージョンが古いので、最新の `ruby 2.4.2`と`Rails 5.1.2`を使うようにする。
-
-次のコマンドを１行ずつ打っていって、最新のRailsを使えるようなります。
-1. `$ cd ~/.rbenv/plugins/ruby-build `
-2. `$ git pull origin master`
-3. `$ cd`
-4. `$ rbenv install 2.4.2`
-5. `$ rbenv global 2.4.2`
-6. `$ gem install rails -v '5.1.2'`
-7. `$ ruby --version` や `rails --version` などでちゃんと指定したバージョンになっているか確認してください。
-
-
 ### 動作確認
 
 もしちゃんと開発できるか不安であれば、
@@ -82,6 +67,18 @@ rails server
 # ホストOS (お手持ちのパソコン) のブラウザを立ち上げ、
 # アドレズバーに http://localhost:3000/ を打ち込んで画面が開くか確認する
 ```
+
+### 他のRailsバージョンを使う
+
+Railsには様々なバージョンがあります。
+このツールでは、最新版のRailsが使えるようになっていますが、過去のバージョンを使うこともできます。
+`vagrant ssh`でログインしたあと、次のコマンドを１行ずつ打っていって、特定のバージョンのRailsを使えるようにできます。
+
+今回は`Rails 5.0.0`をインストールしてみましょう。
+1. `$ rbenv install 2.3.0`
+2. `$ rbenv global 2.3.0`
+3. `$ gem install rails -v '5.0.0'`
+4. `$ ruby --version` や `rails --version` などでちゃんと指定したバージョンになっているか確認してください。
 
 ### 注意点
 

--- a/README.md
+++ b/README.md
@@ -71,15 +71,13 @@ Railsチュートリアルが始められる環境が整います (Windows 8 / M
 git clone https://github.com/yasslab/sample_apps.git
 cd sample_apps/5_1_2/ch14
 bundle install
-bundle exec rake db:migrate
-bundle exec rake db:populate
-bundle exec rake db:test:prepare
+rails db:migrate
 
 # テストが通ることを確認する
-bundle exec rspec
+rails test
 
 # rails server が立ち上がるか確認する
-bundle exec rails server
+rails server
 
 # ホストOS (お手持ちのパソコン) のブラウザを立ち上げ、
 # アドレズバーに http://localhost:3000/ を打ち込んで画面が開くか確認する

--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ Railsチュートリアルが始められる環境が整います (Windows 8 / M
 6. `vagrant ssh` でゲストOSにログインする
 7. `ruby --version` や `rails --version` でちゃんと動くか確かめる
 
+### 最新版のRailsを使う
+ステップ`7.`を行なった際に表示されるバージョンが`ruby 2.0.0p643...`と`Rails 4.0.5`だ
+
+バージョンが古いので、最新の `ruby 2.4.2`と`Rails 5.1.2`を使うようにする。
+
+次のコマンドを１行ずつ打っていって、最新のRailsを使えるようなります。
+1. `$ cd ~/.rbenv/plugins/ruby-build `
+2. `$ git pull origin master`
+3. `$ cd`
+4. `$ rbenv install 2.4.2`
+5. `$ rbenv global 2.4.2`
+6. `$ gem install rails -v '5.1.2'`
+7. `$ ruby --version` や `rails --version` などでちゃんと指定したバージョンになっているか確認してください。
+
 
 ### 動作確認
 


### PR DESCRIPTION
## やりたいこと

最新版のRailsチュートリアルで作業を進めらるようにしたい。

## やること

- [x]  [README](https://github.com/yasslab/railstutorial.jp_starter_kit/tree/update-reademe_latest_upgrade)に必要なステップと更新を入れる
- [x] Macで作業しながら[メモを更新する](https://gist.github.com/nanophate/d4b26646a333f6cbfab5b21cfb12c6bc)
- [ ] ~~Windows マシンで動くか確認をする~~
- [ ] ~~Linux マシンで動くか確認する~~

## 参考リンク
https://yasslab.qiita.com/shared/items/f1de9007512c88319c5f#windows